### PR TITLE
Changed the response to MethodNotAllowed status 

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,6 +4,8 @@ namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -46,6 +48,11 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
+        $method = $request->method();
+
+        if ($exception instanceof MethodNotAllowedHttpException || $exception instanceof NotFoundHttpException) {
+            return response()->json('Puslapio pasiekti negalima.', 404);
+        }
         return parent::render($request, $exception);
     }
 }


### PR DESCRIPTION
Some routes were throwing 405 status, which has to be presented in html form instead of raw error message